### PR TITLE
Response Model for Query Specs with Only Optional Fields

### DIFF
--- a/examples/spec/update_and_delete_specs.py
+++ b/examples/spec/update_and_delete_specs.py
@@ -56,4 +56,4 @@ if response.specs:
 # query all specs
 response = client.query_specs(QuerySpecificationsRequest(product_ids=[product]))
 if response.specs:
-    client.delete_specs(ids=[spec.id for spec in response.specs])
+    client.delete_specs(ids=[spec.id for spec in response.specs if spec.id])

--- a/nisystemlink/clients/spec/models/__init__.py
+++ b/nisystemlink/clients/spec/models/__init__.py
@@ -22,7 +22,6 @@ from ._specification import (
     SpecificationType,
     SpecificationUpdated,
     SpecificationUserManaged,
-    SpecificationWithHistory,
 )
 from ._update_specs_request import (
     UpdatedSpecification,

--- a/nisystemlink/clients/spec/models/__init__.py
+++ b/nisystemlink/clients/spec/models/__init__.py
@@ -12,7 +12,12 @@ from ._create_specs_request import (
     CreateSpecificationsRequest,
 )
 from ._delete_specs_request import DeleteSpecificationsPartialSuccess
-from ._query_specs import QuerySpecificationsRequest, QuerySpecifications
+from ._query_specs import (
+    Projection,
+    QuerySpecificationsRequest,
+    QuerySpecifications,
+    SpecificationWithOptionalFields,
+)
 from ._specification import (
     Specification,
     SpecificationCreation,

--- a/nisystemlink/clients/spec/models/_query_specs.py
+++ b/nisystemlink/clients/spec/models/_query_specs.py
@@ -3,7 +3,7 @@ from typing import List, Optional
 
 from nisystemlink.clients.core._uplink._json_model import JsonModel
 from nisystemlink.clients.core._uplink._with_paging import WithPaging
-from nisystemlink.clients.spec.models._specification import SpecificationWithHistory
+from nisystemlink.clients.spec.models._specification import SpecificationType, SpecificationWithHistory
 
 
 class Projection(str, Enum):
@@ -103,10 +103,31 @@ class QuerySpecificationsRequest(JsonModel):
     """
 
 
+class SpecificationWithOnlyOptionalFields(SpecificationWithHistory):
+    """A full specification with update and create history with only optional fields"""
+
+    product_id: Optional[str] = None
+    """Id of the product to which the specification will be associated."""
+
+    spec_id: Optional[str] = None
+
+    type: Optional[SpecificationType] = None
+    """Type of the specification."""
+
+    id : Optional[str] = None
+    """The global Id of the specification."""
+
+    version: Optional[int] = None
+    """
+    Current version of the specification.
+
+    When an update is applied, the version is automatically incremented.
+    """
+
 class QuerySpecifications(WithPaging):
     """The list of matching specifications and a continuation token to get the next items."""
 
-    specs: Optional[List[SpecificationWithHistory]] = None
+    specs: Optional[List[SpecificationWithOnlyOptionalFields]] = None
     """List of queried specifications.
 
     An empty list indicates that there are no specifications meeting the criteria provided in the

--- a/nisystemlink/clients/spec/models/_query_specs.py
+++ b/nisystemlink/clients/spec/models/_query_specs.py
@@ -1,4 +1,3 @@
-from datetime import datetime
 from enum import Enum
 from typing import Dict, List, Optional
 
@@ -6,8 +5,10 @@ from nisystemlink.clients.core._uplink._json_model import JsonModel
 from nisystemlink.clients.core._uplink._with_paging import WithPaging
 from nisystemlink.clients.spec.models._specification import (
     Condition,
+    SpecificationCreation,
     SpecificationLimit,
     SpecificationType,
+    SpecificationUpdated,
 )
 
 
@@ -108,7 +109,7 @@ class QuerySpecificationsRequest(JsonModel):
     """
 
 
-class SpecificationWithOptionalFields(JsonModel):
+class SpecificationWithOptionalFields(SpecificationCreation, SpecificationUpdated):
     """A full specification with update and create history with only optional fields"""
 
     id: Optional[str] = None
@@ -170,18 +171,6 @@ class SpecificationWithOptionalFields(JsonModel):
     """Additional properties associated with the specification."""
 
     """When the spec was created and when."""
-
-    created_at: Optional[datetime] = None
-    """ISO-8601 formatted timestamp indicating when the specification was created."""
-
-    created_by: Optional[str] = None
-    """Id of the user who created the specification."""
-
-    updated_at: Optional[datetime] = None
-    """ISO-8601 formatted timestamp indicating when the specification was last updated."""
-
-    updated_by: Optional[str] = None
-    """Id of the user who last updated the specification."""
 
 
 class QuerySpecifications(WithPaging):

--- a/nisystemlink/clients/spec/models/_query_specs.py
+++ b/nisystemlink/clients/spec/models/_query_specs.py
@@ -3,7 +3,10 @@ from typing import List, Optional
 
 from nisystemlink.clients.core._uplink._json_model import JsonModel
 from nisystemlink.clients.core._uplink._with_paging import WithPaging
-from nisystemlink.clients.spec.models._specification import SpecificationType, SpecificationWithHistory
+from nisystemlink.clients.spec.models._specification import (
+    SpecificationType,
+    SpecificationWithHistory,
+)
 
 
 class Projection(str, Enum):
@@ -103,7 +106,7 @@ class QuerySpecificationsRequest(JsonModel):
     """
 
 
-class SpecificationWithOnlyOptionalFields(SpecificationWithHistory):
+class SpecificationWithOptionalFields(SpecificationWithHistory):
     """A full specification with update and create history with only optional fields"""
 
     product_id: Optional[str] = None
@@ -114,7 +117,7 @@ class SpecificationWithOnlyOptionalFields(SpecificationWithHistory):
     type: Optional[SpecificationType] = None
     """Type of the specification."""
 
-    id : Optional[str] = None
+    id: Optional[str] = None
     """The global Id of the specification."""
 
     version: Optional[int] = None
@@ -124,10 +127,11 @@ class SpecificationWithOnlyOptionalFields(SpecificationWithHistory):
     When an update is applied, the version is automatically incremented.
     """
 
+
 class QuerySpecifications(WithPaging):
     """The list of matching specifications and a continuation token to get the next items."""
 
-    specs: Optional[List[SpecificationWithOnlyOptionalFields]] = None
+    specs: Optional[List[SpecificationWithOptionalFields]] = None
     """List of queried specifications.
 
     An empty list indicates that there are no specifications meeting the criteria provided in the

--- a/nisystemlink/clients/spec/models/_query_specs.py
+++ b/nisystemlink/clients/spec/models/_query_specs.py
@@ -1,11 +1,13 @@
+from datetime import datetime
 from enum import Enum
-from typing import List, Optional
+from typing import Dict, List, Optional
 
 from nisystemlink.clients.core._uplink._json_model import JsonModel
 from nisystemlink.clients.core._uplink._with_paging import WithPaging
 from nisystemlink.clients.spec.models._specification import (
+    Condition,
+    SpecificationLimit,
     SpecificationType,
-    SpecificationWithHistory,
 )
 
 
@@ -106,16 +108,8 @@ class QuerySpecificationsRequest(JsonModel):
     """
 
 
-class SpecificationWithOptionalFields(SpecificationWithHistory):
+class SpecificationWithOptionalFields(JsonModel):
     """A full specification with update and create history with only optional fields"""
-
-    product_id: Optional[str] = None
-    """Id of the product to which the specification will be associated."""
-
-    spec_id: Optional[str] = None
-
-    type: Optional[SpecificationType] = None
-    """Type of the specification."""
 
     id: Optional[str] = None
     """The global Id of the specification."""
@@ -126,6 +120,68 @@ class SpecificationWithOptionalFields(SpecificationWithHistory):
 
     When an update is applied, the version is automatically incremented.
     """
+
+    product_id: Optional[str] = None
+    """Id of the product to which the specification will be associated."""
+
+    spec_id: Optional[str] = None
+    """User provided value using which the specification will be identified.
+
+    This should be unique for a product and workspace combination.
+    """
+
+    workspace: Optional[str] = None
+    """Id of the workspace to which the specification will be associated.
+
+    Default workspace will be taken if the value is not given.
+    """
+
+    name: Optional[str] = None
+    """Name of the specification."""
+
+    category: Optional[str] = None
+    """Category of the specification."""
+
+    type: Optional[SpecificationType] = None
+    """Type of the specification."""
+
+    symbol: Optional[str] = None
+    """Short form identifier of the specification."""
+
+    block: Optional[str] = None
+    """Block name of the specification.
+
+    Typically a block is one of the subsystems of the overall product being specified.
+    """
+
+    limit: Optional[SpecificationLimit] = None
+    """The limits for this spec."""
+
+    unit: Optional[str] = None
+    """Unit of the specification."""
+
+    conditions: Optional[List[Condition]] = None
+    """Conditions associated with the specification."""
+
+    keywords: Optional[List[str]] = None
+    """Keywords or phrases associated with the specification."""
+
+    properties: Optional[Dict[str, str]] = None
+    """Additional properties associated with the specification."""
+
+    """When the spec was created and when."""
+
+    created_at: Optional[datetime] = None
+    """ISO-8601 formatted timestamp indicating when the specification was created."""
+
+    created_by: Optional[str] = None
+    """Id of the user who created the specification."""
+
+    updated_at: Optional[datetime] = None
+    """ISO-8601 formatted timestamp indicating when the specification was last updated."""
+
+    updated_by: Optional[str] = None
+    """Id of the user who last updated the specification."""
 
 
 class QuerySpecifications(WithPaging):

--- a/nisystemlink/clients/spec/models/_specification.py
+++ b/nisystemlink/clients/spec/models/_specification.py
@@ -127,9 +127,3 @@ class SpecificationUpdated(JsonModel):
 
     updated_by: Optional[str] = None
     """Id of the user who last updated the specification."""
-
-
-class SpecificationWithHistory(
-    Specification, SpecificationCreation, SpecificationUpdated
-):
-    """A full specification with update and create history."""

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -276,3 +276,19 @@ class TestSpec:
         voltage_spec = response.specs[0]
         assert voltage_spec.conditions
         assert len(voltage_spec.conditions) == 2
+
+    def test__query_spec_projection_columns__columns_returned(
+        self, client: SpecClient, create_specs, create_specs_for_query, product
+    ):
+        requset = QuerySpecificationsRequest(
+            product_ids=[product], projection=["SPEC_ID", "NAME"]
+        )
+        response = client.query_specs(requset)
+        assert response.specs
+        assert len(response.specs) == 3
+        specs = [vars(spec) for spec in response.specs]
+        spec_columns = list(set(key for spec in specs for key in spec.keys() if spec[key] is not None))
+        assert len(spec_columns) == 2
+        assert "spec_id" in spec_columns
+        assert "name" in spec_columns
+ 

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -12,6 +12,7 @@ from nisystemlink.clients.spec.models import (
     CreateSpecificationsPartialSuccess,
     CreateSpecificationsRequest,
     NumericConditionValue,
+    Projection,
     QuerySpecificationsRequest,
     Specification,
     SpecificationDefinition,
@@ -281,15 +282,15 @@ class TestSpec:
         self, client: SpecClient, create_specs, create_specs_for_query, product
     ):
         request = QuerySpecificationsRequest(
-            product_ids=[product], projection=["SPEC_ID", "NAME"]
+            product_ids=[product], projection=[Projection.SPEC_ID, Projection.NAME]
         )
         response = client.query_specs(request)
         assert response.specs
         assert len(response.specs) == 3
         specs = [vars(spec) for spec in response.specs]
-        spec_columns = list(
-            set(key for spec in specs for key in spec.keys() if spec[key] is not None)
-        )
+        spec_columns = {
+            key for spec in specs for key in spec.keys() if spec[key] is not None
+        }
         assert len(spec_columns) == 2
         assert "spec_id" in spec_columns
         assert "name" in spec_columns

--- a/tests/integration/spec/test_spec.py
+++ b/tests/integration/spec/test_spec.py
@@ -280,15 +280,16 @@ class TestSpec:
     def test__query_spec_projection_columns__columns_returned(
         self, client: SpecClient, create_specs, create_specs_for_query, product
     ):
-        requset = QuerySpecificationsRequest(
+        request = QuerySpecificationsRequest(
             product_ids=[product], projection=["SPEC_ID", "NAME"]
         )
-        response = client.query_specs(requset)
+        response = client.query_specs(request)
         assert response.specs
         assert len(response.specs) == 3
         specs = [vars(spec) for spec in response.specs]
-        spec_columns = list(set(key for spec in specs for key in spec.keys() if spec[key] is not None))
+        spec_columns = list(
+            set(key for spec in specs for key in spec.keys() if spec[key] is not None)
+        )
         assert len(spec_columns) == 2
         assert "spec_id" in spec_columns
         assert "name" in spec_columns
- 


### PR DESCRIPTION
- [x] This contribution adheres to [CONTRIBUTING.md](https://github.com/ni/nisystemlink-clients-python/blob/master/CONTRIBUTING.md).

### What does this Pull Request accomplish?

- Adds a response model for `query specs` where all the fields of the model are made optional.

### Why should this Pull Request be merged?

- The column projection for `query specs` works only if all the fields are optional in the response model.

### What testing has been done?

- Automated integration tests are included.
